### PR TITLE
0.0.2 complete unit test coverage, simplified fn sigs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module sqlinsert
 
 go 1.18
+
+require github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=

--- a/sqlinsert.go
+++ b/sqlinsert.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 )
 
-// StructTag specifies the struct tag key for the column name. Default is `col`.
-var StructTag = `col`
+// UseStructTag specifies the struct tag key for the column name. Default is `col`.
+var UseStructTag = `col`
 
 // TokenType represents a token in a SQL statement, whether column or value expression.
 type TokenType int
@@ -18,7 +18,7 @@ const (
 
 	/* COLUMN TokenType */
 
-	// ColumnNameTokenType uses the column name from the struct tag specified by StructTag.
+	// ColumnNameTokenType uses the column name from the struct tag specified by UseStructTag.
 	// INSERT INTO tbl (foo, bar, ... baz)
 	ColumnNameTokenType TokenType = 0
 
@@ -26,20 +26,23 @@ const (
 
 	// QuestionMarkTokenType uses question marks as value-tokens.
 	// VALUES (?, ?, ... ?) -- MySQL, SingleStore
-	QuestionMarkTokenType = 1
+	QuestionMarkTokenType TokenType = 1
 
-	// AtColumnNameTokenType uses @ followed by the column name from the struct tag specified by StructTag.
+	// AtColumnNameTokenType uses @ followed by the column name from the struct tag specified by UseStructTag.
 	// VALUES (@foo, @bar, ... @baz) -- MySQL, SingleStore
-	AtColumnNameTokenType = 2
+	AtColumnNameTokenType TokenType = 2
 
 	// OrdinalNumberTokenType uses % plus the value of an ordered sequence of integers starting at 1.
 	// %1, %2, ... %n -- Postgres
-	OrdinalNumberTokenType = 3
+	OrdinalNumberTokenType TokenType = 3
 
-	// ColonTokenType uses : followed by the column name from the struct tag specified by StructTag.
+	// ColonTokenType uses : followed by the column name from the struct tag specified by UseStructTag.
 	// :foo, :bar, ... :baz -- Oracle
-	ColonTokenType = 4
+	ColonTokenType TokenType = 4
 )
+
+// UseTokenType specifies the token type to use for values. Default is the question mark (?).
+var UseTokenType = QuestionMarkTokenType
 
 // InsertWith models functionality needed to execute a SQL INSERT statement with database/sql via Conn, DB, or Tx.
 type InsertWith interface {
@@ -51,11 +54,11 @@ type InsertWith interface {
 type Inserter interface {
 	Tokenize(tokenType TokenType) string
 	Columns() string
-	Params(tokenType TokenType) string
-	SQL(tokenType TokenType) string
+	Params() string
+	SQL() string
 	Args() []interface{}
-	Insert(tokenType TokenType, with InsertWith) (*sql.Stmt, error)
-	InsertContext(tokenType TokenType, with InsertWith) (*sql.Stmt, error)
+	Insert(with InsertWith) (*sql.Stmt, error)
+	InsertContext(ctx context.Context, with InsertWith) (*sql.Stmt, error)
 }
 
 // Insert models data used to produce a valid SQL INSERT statement with bind args.
@@ -82,15 +85,15 @@ func (ins *Insert) Tokenize(tokenType TokenType) string {
 	for i := 0; i < ins.RowType.NumField(); i++ {
 		switch tokenType {
 		case ColumnNameTokenType:
-			b.WriteString(ins.RowType.Field(i).Tag.Get(StructTag))
+			b.WriteString(ins.RowType.Field(i).Tag.Get(UseStructTag))
 		case QuestionMarkTokenType:
 			_, _ = fmt.Fprint(&b, `?`)
 		case AtColumnNameTokenType:
-			_, _ = fmt.Fprintf(&b, `@%s`, ins.RowType.Field(i).Tag.Get(StructTag))
+			_, _ = fmt.Fprintf(&b, `@%s`, ins.RowType.Field(i).Tag.Get(UseStructTag))
 		case OrdinalNumberTokenType:
 			_, _ = fmt.Fprintf(&b, `$%d`, i+1)
 		case ColonTokenType:
-			_, _ = fmt.Fprintf(&b, `:%s`, ins.RowType.Field(i).Tag.Get(StructTag))
+			_, _ = fmt.Fprintf(&b, `:%s`, ins.RowType.Field(i).Tag.Get(UseStructTag))
 		}
 		if i < ins.RowType.NumField()-1 {
 			b.WriteString(`, `)
@@ -105,15 +108,15 @@ func (ins *Insert) Columns() string {
 }
 
 // Params returns the comma-separated list of bind param tokens for the SQL INSERT statement.
-func (ins *Insert) Params(tokenType TokenType) string {
-	return ins.Tokenize(tokenType)
+func (ins *Insert) Params() string {
+	return ins.Tokenize(UseTokenType)
 }
 
 // SQL returns the full parameterized SQL INSERT statement.
-func (ins *Insert) SQL(tokenType TokenType) string {
+func (ins *Insert) SQL() string {
 	var insertSQL strings.Builder
 	_, _ = fmt.Fprintf(&insertSQL, `INSERT INTO %s (%s) VALUES (%s)`,
-		ins.Table, ins.Columns(), ins.Params(tokenType))
+		ins.Table, ins.Columns(), ins.Params())
 	return insertSQL.String()
 }
 
@@ -127,8 +130,8 @@ func (ins *Insert) Args() []interface{} {
 }
 
 // Insert prepares and executes a SQL INSERT statement on a *sql.Conn, *sql.DB, *sql.Tx, or equivalent interface supporting Prepare(string).
-func (ins *Insert) Insert(tokenType TokenType, with InsertWith) (*sql.Stmt, error) {
-	stmt, err := with.Prepare(ins.SQL(tokenType))
+func (ins *Insert) Insert(with InsertWith) (*sql.Stmt, error) {
+	stmt, err := with.Prepare(ins.SQL())
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +143,8 @@ func (ins *Insert) Insert(tokenType TokenType, with InsertWith) (*sql.Stmt, erro
 }
 
 // InsertContext prepares and executes a SQL INSERT statement on a *sql.Conn, *sql.DB, *sql.Tx, or equivalent interface supporting PrepareContext(context.Context, string).
-func (ins *Insert) InsertContext(ctx context.Context, tokenType TokenType, with InsertWith) (*sql.Stmt, error) {
-	stmt, err := with.Prepare(ins.SQL(tokenType))
+func (ins *Insert) InsertContext(ctx context.Context, with InsertWith) (*sql.Stmt, error) {
+	stmt, err := with.Prepare(ins.SQL())
 	if err != nil {
 		return nil, err
 	}

--- a/sqlinsert_test.go
+++ b/sqlinsert_test.go
@@ -1,16 +1,22 @@
 package sqlinsert
 
 import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"github.com/DATA-DOG/go-sqlmock"
 	"reflect"
+	"regexp"
 	"testing"
 	"time"
 )
 
-type CandyInsert struct {
+type candyInsert struct {
 	Id          string    `col:"id"`
 	Name        string    `col:"candy_name"`
 	FormFactor  string    `col:"form_factor"`
-	Description []string  `col:"description"`
+	Description string    `col:"description"`
 	Mfr         string    `col:"manufacturer"`
 	Weight      float64   `col:"weight_grams"`
 	Timestamp   time.Time `col:"ts"`
@@ -18,14 +24,36 @@ type CandyInsert struct {
 
 var tbl = `candy`
 
-var rec = CandyInsert{
+var rec = candyInsert{
 	Id:          `c0600afd-78a7-4a1a-87c5-1bc48cafd14e`,
 	Name:        `Gougat`,
 	FormFactor:  `Package`,
-	Description: []string{`tastes`, `like`, `gopher`, `feed`},
+	Description: `tastes like gopher feed`,
 	Mfr:         `Gouggle`,
 	Weight:      1.16180,
 	Timestamp:   time.Time{},
+}
+
+var valuesTokenTypes = []TokenType{
+	QuestionMarkTokenType,
+	AtColumnNameTokenType,
+	OrdinalNumberTokenType,
+	ColonTokenType,
+}
+
+type failingMock struct {
+}
+
+func (*failingMock) Prepare(query string) (*sql.Stmt, error) {
+	_ = (func(string) interface{} { return nil })(query)
+	err := errors.New(`driver-level failure, cannot execute query`)
+	return nil, err
+}
+
+func (*failingMock) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	_ = (func(context.Context, string) interface{} { return nil })(ctx, query)
+	err := errors.New(`driver-level failure, cannot execute query`)
+	return nil, err
 }
 
 func TestNewInsert(t *testing.T) {
@@ -39,7 +67,7 @@ func TestNewInsert(t *testing.T) {
 	if naked.Table != built.Table {
 		t.Fatalf(`expected NewInsert builder to return struct with table identical to that of test object`)
 	}
-	if !reflect.DeepEqual(naked.Record.(CandyInsert), built.Record.(CandyInsert)) {
+	if !reflect.DeepEqual(naked.Record.(candyInsert), built.Record.(candyInsert)) {
 		t.Fatalf(`expected NewInsert builder to return struct with record values identical to those of test object`)
 	}
 }
@@ -99,18 +127,20 @@ func TestColumns(t *testing.T) {
 }
 
 func TestParams(t *testing.T) {
+	UseTokenType = QuestionMarkTokenType
 	ins := NewInsert(tbl, rec)
 	expected := `?, ?, ?, ?, ?, ?, ?`
-	params := ins.Params(QuestionMarkTokenType)
+	params := ins.Params()
 	if expected != params {
 		t.Fatalf(`expected "%s", got "%s"`, expected, params)
 	}
 }
 
 func TestSQL(t *testing.T) {
+	UseTokenType = OrdinalNumberTokenType
 	ins := NewInsert(tbl, rec)
 	expected := `INSERT INTO candy (id, candy_name, form_factor, description, manufacturer, weight_grams, ts) VALUES ($1, $2, $3, $4, $5, $6, $7)`
-	insertSQL := ins.SQL(OrdinalNumberTokenType)
+	insertSQL := ins.SQL()
 	if expected != insertSQL {
 		t.Fatalf(`expected "%s", got "%s"`, expected, insertSQL)
 	}
@@ -122,7 +152,7 @@ func TestArgs(t *testing.T) {
 		`c0600afd-78a7-4a1a-87c5-1bc48cafd14e`,
 		`Gougat`,
 		`Package`,
-		[]string{`tastes`, `like`, `gopher`, `feed`},
+		`tastes like gopher feed`,
 		`Gouggle`,
 		1.1618,
 		time.Time{},
@@ -131,4 +161,76 @@ func TestArgs(t *testing.T) {
 	if !reflect.DeepEqual(expected, args) {
 		t.Fatalf(`expected "%s", got "%s"`, expected, args)
 	}
+}
+
+func TestInsert(t *testing.T) {
+	for tt := range valuesTokenTypes {
+		UseTokenType = TokenType(tt)
+		ins := NewInsert(tbl, rec)
+		s := regexp.QuoteMeta(ins.SQL())
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf(`failed to construct SQL mock %s`, err)
+		}
+		mock.ExpectPrepare(s)
+		mock.ExpectExec(s).WillReturnResult(sqlmock.NewResult(1, 1))
+		_, err = ins.Insert(db)
+		if err != nil {
+			t.Fatalf(`failed at Insert, could not execute SQL statement %s`, err)
+		}
+	}
+}
+
+func TestInsertContext(t *testing.T) {
+	for tt := range valuesTokenTypes {
+		UseTokenType = TokenType(tt)
+		ins := NewInsert(tbl, rec)
+		s := regexp.QuoteMeta(ins.SQL())
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf(`failed to construct SQL mock %s`, err)
+		}
+		mock.ExpectPrepare(s)
+		mock.ExpectExec(s).WillReturnResult(sqlmock.NewResult(1, 1))
+		_, err = ins.InsertContext(context.Background(), db)
+		if err != nil {
+			t.Fatalf(`failed at InsertContext, could not execute SQL statement %s`, err)
+		}
+	}
+}
+
+func TestInsertError(t *testing.T) {
+	fm := &failingMock{}
+	UseTokenType = QuestionMarkTokenType
+	ins := NewInsert(tbl, rec)
+	s := regexp.QuoteMeta(ins.SQL())
+	_, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf(`failed to construct SQL mock %s`, err)
+	}
+	mock.ExpectPrepare(s)
+	mock.ExpectExec(s).WillReturnResult(sqlmock.NewResult(1, 1))
+	_, err = ins.Insert(fm)
+	if err == nil {
+		t.Fatalf(`expected Insert() to fail, but it succeeded`)
+	}
+	fmt.Printf(`simulation of driver-level error succeeded: %s`, err)
+}
+
+func TestInsertContextError(t *testing.T) {
+	fm := &failingMock{}
+	UseTokenType = QuestionMarkTokenType
+	ins := NewInsert(tbl, rec)
+	s := regexp.QuoteMeta(ins.SQL())
+	_, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf(`failed to construct SQL mock %s`, err)
+	}
+	mock.ExpectPrepare(s)
+	mock.ExpectExec(s).WillReturnResult(sqlmock.NewResult(1, 1))
+	_, err = ins.InsertContext(context.Background(), fm)
+	if err == nil {
+		t.Fatalf(`expected InsertContext() to fail, but it succeeded`)
+	}
+	fmt.Printf(`simulation of driver-level error succeeded: %s`, err)
 }


### PR DESCRIPTION
Unit test coverage at 100% and includes driver-level failures. Removed tokenType param from function sigs in favor of a package-level variable, so that user could set it and forget it.