### PR TITLE
v0.1.2-beta Support Go 1.15+. Improve README and comments. Refactor for clarity, scope, lacunae. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # sqlinsert
-Generate SQL INSERT statement with bind parameters directly from a Go struct. Define column names in struct tags. Supports bind parameter token types of MySQL, PostgreSQL, Oracle, SingleStore (MemSQL), SQL Server (T-SQL), and their equivalents. Struct values become bind arguments. Works seamlessly with standard [database/sql](https://pkg.go.dev/database/sql) package. Use SQL string and Args slice piecemeal or use `Insert()` or `InsertContext()` with a `sql.Conn`, `sql.DB`, or `sql.Tx` to execute the INSERT statement directly.  
+Generate SQL INSERT statement with bind parameters directly from a Go struct.  
 [![Go Reference](https://pkg.go.dev/badge/github.com/zachvictor/sqlinsert.svg)](https://pkg.go.dev/github.com/zachvictor/sqlinsert)
+
+## Features
+* Define column names in struct tags.
+* Struct values become bind arguments.
+* Use SQL outputs and Args slice piecemeal. Or, use `Insert()`/`InsertContext()` with a `sql.Conn`, `sql.DB`, or `sql.Tx` to execute the INSERT statement directly, all in one blow.
+* Works seamlessly with Go standard library [database/sql](https://pkg.go.dev/database/sql) package. 
+* Supports bind parameter token types of MySQL, PostgreSQL, Oracle, SingleStore (MemSQL), SQL Server (T-SQL), and their equivalents.
+* Supports customized struct tags and token types.
+* Supports Go 1.15 and later.
+* 100% unit test coverage.
+
 ## Example
 ### Given
 ```sql

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/zachvictor/sqlinsert
 
-go 1.18
+go 1.15
 
 require github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/sqlinsert.go
+++ b/sqlinsert.go
@@ -11,7 +11,7 @@ import (
 // UseStructTag specifies the struct tag key for the column name. Default is `col`.
 var UseStructTag = `col`
 
-// TokenType represents a token in a SQL statement, whether column or value expression.
+// TokenType represents a type of token in a SQL INSERT statement, whether column or value expression.
 type TokenType int
 
 const (
@@ -41,13 +41,16 @@ const (
 	ColonTokenType TokenType = 4
 )
 
-// UseTokenType specifies the token type to use for values. Default is the question mark (?).
+// UseTokenType specifies the token type to use for values. Default is the question mark (`?`).
 var UseTokenType = QuestionMarkTokenType
 
-// InsertWith models functionality needed to execute a SQL INSERT statement with database/sql via Conn, DB, or Tx.
+// InsertWith models functionality needed to execute a SQL INSERT statement with database/sql via sql.DB or sql.Tx.
+// Note: sql.Conn is also supported, however, for PrepareContext and ExecContext only.
 type InsertWith interface {
 	Prepare(query string) (*sql.Stmt, error)
 	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 }
 
 // Inserter models functionality to produce a valid SQL INSERT statement with bind args.
@@ -62,40 +65,44 @@ type Inserter interface {
 }
 
 // Insert models data used to produce a valid SQL INSERT statement with bind args.
+// Table is the table name. Record is the struct with column-name tagged fields and the data to be inserted.
+// Private fields recordType and recordValue are used internally with reflection and interfaces to field values.
 type Insert struct {
-	Table    string
-	Record   interface{}
-	RowType  reflect.Type
-	RowValue reflect.Value
+	Table       string
+	Record      interface{}
+	recordType  reflect.Type
+	recordValue reflect.Value
 }
 
-// NewInsert builds a new Insert using a given table-name (string) and row-data (struct).
+// NewInsert builds a new Insert using a given table-name (string) and record data (struct).
+// It is recommended that new NewInsert be used to build every new INSERT; however, if only Insert.Tokenize is
+// needed, a "manually" build Insert will support tokenization as long as Insert.Table and Insert.Record are valid.
 func NewInsert(Table string, Record interface{}) *Insert {
 	return &Insert{
-		Table:    Table,
-		Record:   Record,
-		RowType:  reflect.TypeOf(Record),
-		RowValue: reflect.ValueOf(Record),
+		Table:       Table,
+		Record:      Record,
+		recordType:  reflect.TypeOf(Record),
+		recordValue: reflect.ValueOf(Record),
 	}
 }
 
 // Tokenize translates struct fields into the tokens of SQL column or value expressions.
 func (ins *Insert) Tokenize(tokenType TokenType) string {
 	var b strings.Builder
-	for i := 0; i < ins.RowType.NumField(); i++ {
+	for i := 0; i < ins.recordType.NumField(); i++ {
 		switch tokenType {
 		case ColumnNameTokenType:
-			b.WriteString(ins.RowType.Field(i).Tag.Get(UseStructTag))
+			b.WriteString(ins.recordType.Field(i).Tag.Get(UseStructTag))
 		case QuestionMarkTokenType:
 			_, _ = fmt.Fprint(&b, `?`)
 		case AtColumnNameTokenType:
-			_, _ = fmt.Fprintf(&b, `@%s`, ins.RowType.Field(i).Tag.Get(UseStructTag))
+			_, _ = fmt.Fprintf(&b, `@%s`, ins.recordType.Field(i).Tag.Get(UseStructTag))
 		case OrdinalNumberTokenType:
 			_, _ = fmt.Fprintf(&b, `$%d`, i+1)
 		case ColonTokenType:
-			_, _ = fmt.Fprintf(&b, `:%s`, ins.RowType.Field(i).Tag.Get(UseStructTag))
+			_, _ = fmt.Fprintf(&b, `:%s`, ins.recordType.Field(i).Tag.Get(UseStructTag))
 		}
-		if i < ins.RowType.NumField()-1 {
+		if i < ins.recordType.NumField()-1 {
 			b.WriteString(`, `)
 		}
 	}
@@ -122,14 +129,15 @@ func (ins *Insert) SQL() string {
 
 // Args returns the arguments to be bound in Insert() or the variadic Exec/ExecContext functions in database/sql.
 func (ins *Insert) Args() []interface{} {
-	args := make([]interface{}, ins.RowType.NumField())
-	for i := 0; i < ins.RowType.NumField(); i++ {
-		args[i] = ins.RowValue.Field(i).Interface()
+	args := make([]interface{}, ins.recordType.NumField())
+	for i := 0; i < ins.recordType.NumField(); i++ {
+		args[i] = ins.recordValue.Field(i).Interface()
 	}
 	return args
 }
 
-// Insert prepares and executes a SQL INSERT statement on a *sql.Conn, *sql.DB, *sql.Tx, or equivalent interface supporting Prepare(string).
+// Insert prepares and executes a SQL INSERT statement on a *sql.DB, *sql.Tx,
+// or other Inserter-compatible interface to Prepare and Exec.
 func (ins *Insert) Insert(with InsertWith) (*sql.Stmt, error) {
 	stmt, err := with.Prepare(ins.SQL())
 	if err != nil {
@@ -142,7 +150,8 @@ func (ins *Insert) Insert(with InsertWith) (*sql.Stmt, error) {
 	return stmt, err
 }
 
-// InsertContext prepares and executes a SQL INSERT statement on a *sql.Conn, *sql.DB, *sql.Tx, or equivalent interface supporting PrepareContext(context.Context, string).
+// InsertContext prepares and executes a SQL INSERT statement on a *sql.DB, *sql.Tx, *sql.Conn,
+// or other Inserter-compatible interface to PrepareContext and ExecContext.
 func (ins *Insert) InsertContext(ctx context.Context, with InsertWith) (*sql.Stmt, error) {
 	stmt, err := with.Prepare(ins.SQL())
 	if err != nil {

--- a/sqlinsert_test.go
+++ b/sqlinsert_test.go
@@ -56,12 +56,24 @@ func (*failingMock) PrepareContext(ctx context.Context, query string) (*sql.Stmt
 	return nil, err
 }
 
+func (*failingMock) Exec(query string, args ...interface{}) (sql.Result, error) {
+	_ = (func(string, ...interface{}) interface{} { return nil })(query, args)
+	err := errors.New(`driver-level failure, cannot execute query`)
+	return nil, err
+}
+
+func (*failingMock) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	_ = (func(context.Context, string, ...interface{}) interface{} { return nil })(ctx, query, args)
+	err := errors.New(`driver-level failure, cannot execute query`)
+	return nil, err
+}
+
 func TestNewInsert(t *testing.T) {
 	naked := &Insert{
-		Table:    tbl,
-		Record:   rec,
-		RowType:  reflect.TypeOf(rec),
-		RowValue: reflect.ValueOf(rec),
+		Table:       tbl,
+		Record:      rec,
+		recordType:  reflect.TypeOf(rec),
+		recordValue: reflect.ValueOf(rec),
 	}
 	built := NewInsert(tbl, rec)
 	if naked.Table != built.Table {


### PR DESCRIPTION
v0.1.2-beta Support Go 1.15+. Improve comments and naming. Put Exec and ExecContext in interface (lacunae fix). Make reflection properties private.