### PR TITLE
Set go version in go.mod to min supported version - go 1.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/zachvictor/sqlinsert
 
-go 1.15
+go 1.9
 
 require github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
Confirmed support for go 1.9 but did not update main go.mod 🤦‍♂️